### PR TITLE
[#4]Fix redirectUri become undefined

### DIFF
--- a/src/screens/Home.js
+++ b/src/screens/Home.js
@@ -13,7 +13,7 @@ const Home = () => {
     <FuroProvider
       domain={process.env.REACT_APP_DOMAIN_URL || "https://auth.furo.one"}
       clientId={pid ? pid : clientId}
-      redirectUri={window.location.origin + `/${pid && pid}`}
+      redirectUri={window.location.origin + `/${pid ? pid : clientId}`}
       apiUrl={process.env.REACT_APP_API_URL || "https://api.furo.one"}
     >
       <div style={{ margin: 30 }}>


### PR DESCRIPTION
Issue: #4 

## Purpose

Fix redirectUri become undefined.

## Cause and Solution

`pid && pid` return undefined when pid is undefined. So it doesn't help handling exceptional value.
I solve this problem by using clientId when pid is undefined.
